### PR TITLE
Update delete to use a newer destroy playbook from agnosticd

### DIFF
--- a/4.x/delete_ocp4_workshop.sh
+++ b/4.x/delete_ocp4_workshop.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 OUR_DIR=`pwd`
 
 OS="$(uname)"
@@ -14,5 +15,7 @@ fi
 
 pushd .
 cd ${AGNOSTICD_HOME}
-ansible-playbook  ./ansible/configs/ocp4-cluster/destroy_env.yml ${OUR_DIR}/../archive_deleted.yml -e ACTION="destroy" -e @${OUR_DIR}/ocp4_vars.yml -e @${OUR_DIR}/my_vars.yml -e @${OUR_DIR}/../secret.yml "$@"
+ansible-playbook ${AGNOSTICD_HOME}/ansible/destroy.yml ${OUR_DIR}/../archive_deleted.yml -e ACTION="destroy" -e @${OUR_DIR}/ocp4_vars.yml -e @${OUR_DIR}/my_vars.yml -e @${OUR_DIR}/../secret.yml -e @${OUR_DIR}/../secret.ocp4.yml "$@"
+rc=$?
 popd
+exit ${rc}

--- a/4.x/my_vars.yml.sample
+++ b/4.x/my_vars.yml.sample
@@ -25,3 +25,8 @@ aws_region: us-west-2
 cloud_tags: # list of custom tags to add to your aws resources
 - owner: "{{ email }}"
 
+
+# https://access.redhat.com/solutions/7007136
+# Need at least 4.11.36 or 4.12.12
+# ocp4_installer_version: "4.13.0"
+


### PR DESCRIPTION
I was unable to delete OCP 4 cluster I provisioned until I changed to use this destroy playbook.